### PR TITLE
Custom formatting issue

### DIFF
--- a/src/main/java/org/walkmod/javaformatter/writers/EclipseWriter.java
+++ b/src/main/java/org/walkmod/javaformatter/writers/EclipseWriter.java
@@ -155,7 +155,7 @@ public class EclipseWriter extends AbstractFileWriter implements ChainWriter {
 				NodeList children = profilesElem.getChildNodes();
 				boolean loadProfile = false;
 				int childSize = children.getLength();
-				for (int i = 0; i < childSize && loadProfile; i++) {
+				for (int i = 0; i < childSize && !loadProfile; i++) {
 					Node childNode = children.item(i);
 					if (childNode instanceof Element) {
 						Element child = (Element) childNode;
@@ -168,9 +168,7 @@ public class EclipseWriter extends AbstractFileWriter implements ChainWriter {
 									Node settingNode = settings.item(j);
 									if (settingNode instanceof Element) {
 										Element setting = (Element) settingNode;
-										options.put("id",
-												setting.getAttribute("id"));
-										options.put("value",
+										options.put(setting.getAttribute("id"),
 												setting.getAttribute("value"));
 									}
 								}


### PR DESCRIPTION
Issue: We are trying to use custom formatter.xml for formatting. But we are not getting the expected formatting.

RCA: We have debugged the writer EclipseWriter.java and found that properties defined in the formatter.xml file, are not reading in getOptionsFromConfigFile file.

Fix: We have found that the variable “loadProfile” is used in for loop condition. Since its default value is “false” it will not enter into the loop. We changed the condition to “!loadProfile”.

*Inside the loop to prevent loading multiple PROFILES, “loadProfile” is set to true.

Also while adding formatting properties to the “options” map used “id” and “value” key for adding property “name” and “value”.  Here the id and value will be overwritten for every iteration and latest property name and value will be return from getOptionsFromConfigFile.

We fixed this also.
